### PR TITLE
Add getTradeHistory method

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ const book = await publicClient.getOrderBook({
 });
 ```
 
+- [`getTradeHistory`](https://docs.gemini.com/rest-api/#trade-history)
+
+```javascript
+const symbol = 'zecltc';
+const since = 1547146811;
+const limit_trades = 100;
+const include_breaks = true;
+const trades = await publicClient.getTradeHistory({
+  symbol,
+  since,
+  limit_trades,
+  include_breaks,
+});
+```
+
 - `get`
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,12 @@ declare module 'gemini-node-api' {
     limit_asks?: number;
   } & SymbolFilter;
 
+  export type TradeHistoryFilter = {
+    since?: number;
+    limit_trades?: number;
+    include_breaks?: boolean;
+  } & SymbolFilter;
+
   export type RequestResponse = JSONObject | JSONObject[] | string[];
 
   export type Ticker = {
@@ -42,6 +48,17 @@ declare module 'gemini-node-api' {
   export type OrderBook = {
     bids: BookEntry[];
     asks: BookEntry[];
+  };
+
+  export type Trade = {
+    timestamp: number;
+    timestampms: number;
+    tid: number;
+    price: string;
+    amount: string;
+    exchange: 'gemini';
+    type: 'buy' | 'sell' | 'auction' | 'block';
+    broken?: boolean;
   };
 
   export type PublicClientOptions = {
@@ -63,5 +80,7 @@ declare module 'gemini-node-api' {
     getTicker(options?: SymbolFilter): Promise<Ticker>;
 
     getOrderBook(options?: BookFilter): Promise<OrderBook>;
+
+    getTradeHistory(options?: TradeHistoryFilter): Promise<Trade[]>;
   }
 }

--- a/lib/public.js
+++ b/lib/public.js
@@ -1,6 +1,7 @@
 const request = require('request-promise');
 const Promise = require('bluebird');
 const {
+  API_LIMIT,
   DEFAULT_SYMBOL,
   DEFAULT_TIMEOUT,
   EXCHANGE_API_URL,
@@ -124,6 +125,29 @@ class PublicClient {
     return this.get({
       uri: 'v1/book/' + symbol,
       qs: { limit_bids, limit_asks },
+    });
+  }
+
+  /**
+   * @param {Object} [options]
+   * @param {string} [options.symbol] - Trading symbol.
+   * @param {number} [options.since] - Only return trades after this timestamp.
+   * @param {number} [options.limit_trades] - The maximum number of trades to return.
+   * @param {boolean} [options.include_breaks] - Whether to display broken trades.
+   * @example
+   * const trades = await publicClient.getTradeHistory();
+   * @description Get the trades that have executed since the specified timestamp.
+   * @see {@link https://docs.gemini.com/rest-api/#trade-history|trade-history}
+   */
+  getTradeHistory({
+    symbol = this.symbol,
+    since,
+    limit_trades = API_LIMIT,
+    include_breaks,
+  } = {}) {
+    return this.get({
+      uri: 'v1/trades/' + symbol,
+      qs: { since, limit_trades, include_breaks },
     });
   }
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,3 +1,4 @@
+const API_LIMIT = 500;
 const DEFAULT_SYMBOL = 'btcusd';
 const DEFAULT_TIMEOUT = 10000;
 const EXCHANGE_API_URL = 'https://api.gemini.com';
@@ -13,6 +14,7 @@ const HEADERS = {
 };
 
 module.exports = {
+  API_LIMIT,
   DEFAULT_SYMBOL,
   DEFAULT_TIMEOUT,
   EXCHANGE_API_URL,

--- a/tests/public.spec.js
+++ b/tests/public.spec.js
@@ -4,6 +4,7 @@ const nock = require('nock');
 const { PublicClient } = require('../index.js');
 const publicClient = new PublicClient();
 const {
+  API_LIMIT,
   EXCHANGE_API_URL,
   SANDBOX_API_URL,
   DEFAULT_TIMEOUT,
@@ -306,6 +307,70 @@ suite('PublicClient', () => {
 
     client
       .getOrderBook()
+      .then(data => {
+        assert.deepStrictEqual(data, response);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
+
+  test('.getTradeHistory()', done => {
+    const symbol = 'btcusd';
+    const uri = '/v1/trades/' + symbol;
+    const limit_trades = 1;
+    const include_breaks = true;
+    const since = 2;
+    const response = [
+      {
+        timestamp: 1547146811,
+        timestampms: 1547146811357,
+        tid: 5335307668,
+        price: '3610.85',
+        amount: '0.27413495',
+        exchange: 'gemini',
+        type: 'buy',
+      },
+    ];
+    nock(EXCHANGE_API_URL)
+      .get(uri)
+      .query({ limit_trades, include_breaks, since })
+      .times(1)
+      .reply(200, response);
+
+    publicClient
+      .getTradeHistory({ symbol, limit_trades, include_breaks, since })
+      .then(data => {
+        assert.deepStrictEqual(data, response);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
+
+  test('.getTradeHistory() (with default symbol)', done => {
+    const symbol = 'zecbtc';
+    const uri = '/v1/trades/' + symbol;
+    const limit_trades = API_LIMIT;
+    const response = [
+      {
+        timestamp: 1547146811,
+        timestampms: 1547146811357,
+        tid: 5335307668,
+        price: '3610.85',
+        amount: '0.27413495',
+        exchange: 'gemini',
+        type: 'buy',
+      },
+    ];
+
+    const client = new PublicClient({ symbol });
+    nock(EXCHANGE_API_URL)
+      .get(uri)
+      .query({ limit_trades })
+      .times(1)
+      .reply(200, response);
+
+    client
+      .getTradeHistory()
       .then(data => {
         assert.deepStrictEqual(data, response);
         done();


### PR DESCRIPTION
## PublicClient
 - https://github.com/vansergen/gemini-node-api/commit/30eb02055aa83da965ebb5fbd011044f7e56ece8 Add `getTradeHistory` method

#### Other changes
- https://github.com/vansergen/gemini-node-api/commit/e6a19d1d77511a097f6393a046c837e2f0c4c2da Update tests
- https://github.com/vansergen/gemini-node-api/commit/8331e5a93d12705e88fc82aa509af5fa533e5de7 Update `README`
- https://github.com/vansergen/gemini-node-api/commit/d043f4acff8c1a7eb989b461026b4b1d0dd02cb0 Update `Typescript` definitions