### PR TITLE
Add getCurrentAuction method

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ const trades = await publicClient.getTradeHistory({
 });
 ```
 
+- [`getCurrentAuction`](https://docs.gemini.com/rest-api/#current-auction)
+
+```javascript
+const symbol = 'zecltc';
+const auction = await publicClient.getCurrentAuction({ symbol });
+```
+
 - `get`
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,23 @@ declare module 'gemini-node-api' {
     include_breaks?: boolean;
   } & SymbolFilter;
 
+  export type AuctionInfo = {
+    closed_until_ms?: number;
+    last_auction_eid?: number;
+    last_auction_price?: string;
+    last_auction_quantity?: string;
+    last_highest_bid_price?: string;
+    last_lowest_ask_price?: string;
+    last_collar_price?: string;
+    most_recent_indicative_price?: string;
+    most_recent_indicative_quantity?: string;
+    most_recent_highest_bid_price?: string;
+    most_recent_lowest_ask_price?: string;
+    most_recent_collar_price?: string;
+    next_update_ms?: number;
+    next_auction_ms?: number;
+  };
+
   export type RequestResponse = JSONObject | JSONObject[] | string[];
 
   export type Ticker = {
@@ -82,5 +99,7 @@ declare module 'gemini-node-api' {
     getOrderBook(options?: BookFilter): Promise<OrderBook>;
 
     getTradeHistory(options?: TradeHistoryFilter): Promise<Trade[]>;
+
+    getCurrentAuction(options?: SymbolFilter): Promise<AuctionInfo>;
   }
 }

--- a/lib/public.js
+++ b/lib/public.js
@@ -152,6 +152,18 @@ class PublicClient {
   }
 
   /**
+   * @param {Object} [options]
+   * @param {string} [options.symbol] - Trading symbol.
+   * @example
+   * const auction = await publicClient.getCurrentAuction();
+   * @description Get current auction information.
+   * @see {@link https://docs.gemini.com/rest-api/#current-auction|current-auction}
+   */
+  getCurrentAuction({ symbol = this.symbol } = {}) {
+    return this.get({ uri: 'v1/auction/' + symbol });
+  }
+
+  /**
    * @private
    * @param {...*} [properties]
    * @example

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-node-api",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-node-api",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Gemini Node.js API",
   "main": "index.js",
   "directories": {

--- a/tests/public.spec.js
+++ b/tests/public.spec.js
@@ -377,4 +377,60 @@ suite('PublicClient', () => {
       })
       .catch(error => assert.fail(error));
   });
+
+  test('.getCurrentAuction()', done => {
+    const symbol = 'btcusd';
+    const uri = '/v1/auction/' + symbol;
+    const response = {
+      last_auction_eid: 109929,
+      last_auction_price: '629.92',
+      last_auction_quantity: '430.12917506',
+      last_highest_bid_price: '630.10',
+      last_lowest_ask_price: '632.44',
+      last_collar_price: '631.27',
+      next_auction_ms: 1474567782895,
+      next_update_ms: 1474567662895,
+    };
+    nock(EXCHANGE_API_URL)
+      .get(uri)
+      .times(1)
+      .reply(200, response);
+
+    publicClient
+      .getCurrentAuction({ symbol })
+      .then(data => {
+        assert.deepStrictEqual(data, response);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
+
+  test('.getCurrentAuction() (with default symbol)', done => {
+    const symbol = 'zecbtc';
+    const uri = '/v1/auction/' + symbol;
+    const response = {
+      last_auction_eid: 110085,
+      most_recent_indicative_price: '632.33',
+      most_recent_indicative_quantity: '151.93847124',
+      most_recent_highest_bid_price: '633.26',
+      most_recent_lowest_ask_price: '633.83',
+      most_recent_collar_price: '633.545',
+      next_auction_ms: 1474567782895,
+      next_update_ms: 1474567722895,
+    };
+
+    const client = new PublicClient({ symbol });
+    nock(EXCHANGE_API_URL)
+      .get(uri)
+      .times(1)
+      .reply(200, response);
+
+    client
+      .getCurrentAuction()
+      .then(data => {
+        assert.deepStrictEqual(data, response);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
 });


### PR DESCRIPTION
## PublicClient
 - https://github.com/vansergen/gemini-node-api/commit/d4f397826ef13a4141a08c8f3d8672b03eb5355f Add `getCurrentAuction` method

#### Other changes
- https://github.com/vansergen/gemini-node-api/commit/57c81de599b67af925c592ffb22a1d4a87c55e81 Update tests
- https://github.com/vansergen/gemini-node-api/commit/fbcdd96979af2dc958606ef53c9be1e0ac2780f4 Update `README`
- https://github.com/vansergen/gemini-node-api/commit/846587a272aa4cad7ddd0b7fddea9f218f07d3a4 Update `Typescript` definitions
- https://github.com/vansergen/gemini-node-api/commit/abb5b885a8e149940b365e7e4c0146333d752b17 Update `npm` version