### PR TITLE
Add getAuctionHistory method

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ const symbol = 'zecltc';
 const auction = await publicClient.getCurrentAuction({ symbol });
 ```
 
+- [`getAuctionHistory`](https://docs.gemini.com/rest-api/#auction-history)
+
+```javascript
+const symbol = 'zecltc';
+const since = 1547146811;
+const limit_auction_results = 100;
+const include_indicative = true;
+const history = await publicClient.getAuctionHistory({
+  symbol,
+  since,
+  limit_auction_results,
+  include_indicative,
+});
+```
+
 - `get`
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,22 +30,11 @@ declare module 'gemini-node-api' {
     include_breaks?: boolean;
   } & SymbolFilter;
 
-  export type AuctionInfo = {
-    closed_until_ms?: number;
-    last_auction_eid?: number;
-    last_auction_price?: string;
-    last_auction_quantity?: string;
-    last_highest_bid_price?: string;
-    last_lowest_ask_price?: string;
-    last_collar_price?: string;
-    most_recent_indicative_price?: string;
-    most_recent_indicative_quantity?: string;
-    most_recent_highest_bid_price?: string;
-    most_recent_lowest_ask_price?: string;
-    most_recent_collar_price?: string;
-    next_update_ms?: number;
-    next_auction_ms?: number;
-  };
+  export type AuctionHistoryFilter = {
+    since?: number;
+    limit_auction_results?: number;
+    include_indicative?: boolean;
+  } & SymbolFilter;
 
   export type RequestResponse = JSONObject | JSONObject[] | string[];
 
@@ -78,6 +67,38 @@ declare module 'gemini-node-api' {
     broken?: boolean;
   };
 
+  export type AuctionInfo = {
+    closed_until_ms?: number;
+    last_auction_eid?: number;
+    last_auction_price?: string;
+    last_auction_quantity?: string;
+    last_highest_bid_price?: string;
+    last_lowest_ask_price?: string;
+    last_collar_price?: string;
+    most_recent_indicative_price?: string;
+    most_recent_indicative_quantity?: string;
+    most_recent_highest_bid_price?: string;
+    most_recent_lowest_ask_price?: string;
+    most_recent_collar_price?: string;
+    next_update_ms?: number;
+    next_auction_ms?: number;
+  };
+
+  export type AuctionHistory = {
+    timestamp: number;
+    timestampms: number;
+    auction_id: number;
+    eid: number;
+    event_type: 'indicative' | 'auction';
+    auction_result: 'success' | 'failure';
+    auction_price?: string;
+    auction_quantity?: string;
+    highest_bid_price?: string;
+    lowest_ask_price?: string;
+    collar_price?: string;
+    unmatched_collar_quantity?: string;
+  };
+
   export type PublicClientOptions = {
     symbol?: string;
     sandbox?: boolean;
@@ -101,5 +122,9 @@ declare module 'gemini-node-api' {
     getTradeHistory(options?: TradeHistoryFilter): Promise<Trade[]>;
 
     getCurrentAuction(options?: SymbolFilter): Promise<AuctionInfo>;
+
+    getAuctionHistory(
+      options?: AuctionHistoryFilter
+    ): Promise<AuctionHistory[]>;
   }
 }

--- a/lib/public.js
+++ b/lib/public.js
@@ -164,6 +164,29 @@ class PublicClient {
   }
 
   /**
+   * @param {Object} [options]
+   * @param {string} [options.symbol] - Trading symbol.
+   * @param {number} [options.since] - Only return trades after this timestamp.
+   * @param {number} [options.limit_auction_results] - The maximum number of auction events to return.
+   * @param {boolean} [options.include_indicative] - Whether to include publication of indicative prices and quantities.
+   * @example
+   * const history = await publicClient.getAuctionHistory();
+   * @description Get the auction events.
+   * @see {@link https://docs.gemini.com/rest-api/#auction-history|auction-history}
+   */
+  getAuctionHistory({
+    symbol = this.symbol,
+    since,
+    limit_auction_results = API_LIMIT,
+    include_indicative,
+  } = {}) {
+    return this.get({
+      uri: 'v1/auction/' + symbol + '/history',
+      qs: { since, limit_auction_results, include_indicative },
+    });
+  }
+
+  /**
    * @private
    * @param {...*} [properties]
    * @example

--- a/tests/public.spec.js
+++ b/tests/public.spec.js
@@ -433,4 +433,107 @@ suite('PublicClient', () => {
       })
       .catch(error => assert.fail(error));
   });
+
+  test('.getAuctionHistory()', done => {
+    const symbol = 'btcusd';
+    const uri = '/v1/auction/' + symbol + '/history';
+    const limit_auction_results = 2;
+    const include_indicative = true;
+    const since = 2;
+    const response = [
+      {
+        auction_id: 3,
+        auction_price: '628.775',
+        auction_quantity: '66.32225622',
+        eid: 4066,
+        highest_bid_price: '628.82',
+        lowest_ask_price: '629.48',
+        collar_price: '629.15',
+        auction_result: 'success',
+        timestamp: 1471902531,
+        timestampms: 1471902531225,
+        event_type: 'auction',
+      },
+      {
+        auction_id: 3,
+        auction_price: '628.865',
+        auction_quantity: '89.22776435',
+        eid: 3920,
+        highest_bid_price: '629.59',
+        lowest_ask_price: '629.77',
+        collar_price: '629.68',
+        auction_result: 'success',
+        timestamp: 1471902471,
+        timestampms: 1471902471225,
+        event_type: 'indicative',
+      },
+    ];
+    nock(EXCHANGE_API_URL)
+      .get(uri)
+      .query({ limit_auction_results, include_indicative, since })
+      .times(1)
+      .reply(200, response);
+
+    publicClient
+      .getAuctionHistory({
+        symbol,
+        limit_auction_results,
+        include_indicative,
+        since,
+      })
+      .then(data => {
+        assert.deepStrictEqual(data, response);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
+
+  test('.getAuctionHistory() (with default symbol)', done => {
+    const symbol = 'zecbtc';
+    const uri = '/v1/auction/' + symbol + '/history';
+    const limit_auction_results = API_LIMIT;
+    const response = [
+      {
+        auction_id: 3,
+        auction_price: '628.775',
+        auction_quantity: '66.32225622',
+        eid: 4066,
+        highest_bid_price: '628.82',
+        lowest_ask_price: '629.48',
+        collar_price: '629.15',
+        auction_result: 'success',
+        timestamp: 1471902531,
+        timestampms: 1471902531225,
+        event_type: 'auction',
+      },
+      {
+        auction_id: 3,
+        auction_price: '628.865',
+        auction_quantity: '89.22776435',
+        eid: 3920,
+        highest_bid_price: '629.59',
+        lowest_ask_price: '629.77',
+        collar_price: '629.68',
+        auction_result: 'success',
+        timestamp: 1471902471,
+        timestampms: 1471902471225,
+        event_type: 'indicative',
+      },
+    ];
+
+    const client = new PublicClient({ symbol });
+    nock(EXCHANGE_API_URL)
+      .get(uri)
+      .query({ limit_auction_results })
+      .times(1)
+      .reply(200, response);
+
+    client
+      .getAuctionHistory()
+      .then(data => {
+        assert.deepStrictEqual(data, response);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
 });


### PR DESCRIPTION
## PublicClient
 - https://github.com/vansergen/gemini-node-api/commit/769732dc5dad5eb9735c0df8536b1c020cbfd068 Add `getAuctionHistory` method

#### Other changes
- https://github.com/vansergen/gemini-node-api/commit/85c3b54e71cec527da9ef7b48ecab8dee8c17e97 Update tests
- https://github.com/vansergen/gemini-node-api/commit/c67173c596ac013abe6fb1bf5b99c1dac7485350 Update `README`
- https://github.com/vansergen/gemini-node-api/commit/8b5f0c286427b5ad0aa79af5f4d3c2892f030f89 Update `Typescript` definitions