### PR TITLE
Add Fee and Volume API methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ const secret = 'gemini-api-secret';
 const authClient = new AuthenticatedClient({ key, secret });
 ```
 
+- [`getNotionalVolume`](https://docs.gemini.com/rest-api/#get-notional-volume)
+
+```javascript
+const volume = await authClient.getNotionalVolume();
+```
+
+- [`getTradeVolume`](https://docs.gemini.com/rest-api/#get-trade-volume)
+
+```javascript
+const volume = await authClient.getTradeVolume();
+```
+
 - `post`
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,7 +45,11 @@ declare module 'gemini-node-api' {
     secret: string;
   };
 
-  export type RequestResponse = JSONObject | JSONObject[] | string[];
+  export type RequestResponse =
+    | JSONObject
+    | JSONObject[]
+    | JSONObject[][]
+    | string[];
 
   export type Ticker = {
     bid: string;
@@ -108,6 +112,52 @@ declare module 'gemini-node-api' {
     unmatched_collar_quantity?: string;
   };
 
+  export type NotionalOneDay = {
+    date: string;
+    notional_volume: number;
+  };
+
+  export type NotionalVolume = {
+    account_id?: number;
+    date: string;
+    last_updated_ms: number;
+    web_maker_fee_bps: number;
+    web_taker_fee_bps: number;
+    web_auction_fee_bps: number;
+    api_maker_fee_bps: number;
+    api_taker_fee_bps: number;
+    api_auction_fee_bps: number;
+    fix_maker_fee_bps: number;
+    fix_taker_fee_bps: number;
+    fix_auction_fee_bps: number;
+    block_maker_fee_bps: number;
+    block_taker_fee_bps: number;
+    notional_30d_volume: number;
+    notional_1d_volume: NotionalOneDay[];
+  };
+
+  export type TradeVolume = {
+    account_id: number;
+    symbol: string;
+    base_currency: string;
+    notional_currency: string;
+    data_date: string;
+    total_volume_base: number;
+    maker_buy_sell_ratio: number;
+    buy_maker_base: number;
+    buy_maker_notional: number;
+    buy_maker_count: number;
+    sell_maker_base: number;
+    sell_maker_notional: number;
+    sell_maker_count: number;
+    buy_taker_base: number;
+    buy_taker_notional: number;
+    buy_taker_count: number;
+    sell_taker_base: number;
+    sell_taker_notional: number;
+    sell_taker_count: number;
+  };
+
   export type AuthHeaders = {
     'X-GEMINI-PAYLOAD': string;
     'X-GEMINI-SIGNATURE': string;
@@ -149,6 +199,10 @@ declare module 'gemini-node-api' {
     constructor(options: AuthenticatedClientOptions);
 
     post(options: PostOptions): Promise<RequestResponse>;
+
+    getNotionalVolume(): Promise<NotionalVolume>;
+
+    getTradeVolume(): Promise<TradeVolume[][]>;
   }
 
   export function SignRequest(auth: Auth, payload?: JSONObject): AuthHeaders;

--- a/lib/authenticated.js
+++ b/lib/authenticated.js
@@ -53,6 +53,16 @@ class AuthenticatedClient extends PublicClient {
   }
 
   /**
+   * @example
+   * const volume = await authClient.getNotionalVolume();
+   * @description Get the volume in price currency that has been traded across all pairs over a period of 30 days.
+   * @see {@link https://docs.gemini.com/rest-api/#get-notional-volume|get-notional-volume}
+   */
+  getNotionalVolume() {
+    return this.post({ request: '/v1/notionalvolume' });
+  }
+
+  /**
    * @private
    * @example
    * const nonce = authClient._nonce();

--- a/lib/authenticated.js
+++ b/lib/authenticated.js
@@ -63,6 +63,16 @@ class AuthenticatedClient extends PublicClient {
   }
 
   /**
+   * @example
+   * const volume = await authClient.getTradeVolume();
+   * @description Get trade volume for each symbol.
+   * @see {@link https://docs.gemini.com/rest-api/#get-trade-volume|get-trade-volume}
+   */
+  getTradeVolume() {
+    return this.post({ request: '/v1/tradevolume' });
+  }
+
+  /**
    * @private
    * @example
    * const nonce = authClient._nonce();

--- a/tests/authenticated.spec.js
+++ b/tests/authenticated.spec.js
@@ -68,4 +68,116 @@ suite('AuthenticatedClient', () => {
       })
       .catch(error => assert.fail(error));
   });
+
+  test('.getNotionalVolume()', done => {
+    const response = {
+      web_maker_fee_bps: 100,
+      web_taker_fee_bps: 100,
+      web_auction_fee_bps: 100,
+      api_maker_fee_bps: 35,
+      api_taker_fee_bps: 10,
+      api_auction_fee_bps: 20,
+      fix_maker_fee_bps: 35,
+      fix_taker_fee_bps: 10,
+      fix_auction_fee_bps: 20,
+      block_maker_fee_bps: 50,
+      block_taker_fee_bps: 0,
+      notional_30d_volume: 150.0,
+      last_updated_ms: 1551371446000,
+      date: '2019-02-28',
+      notional_1d_volume: [
+        {
+          date: '2019-02-22',
+          notional_volume: 75.0,
+        },
+        {
+          date: '2019-02-14',
+          notional_volume: 75.0,
+        },
+      ],
+    };
+    const request = '/v1/notionalvolume';
+    const nonce = 1;
+    const payload = { request, nonce };
+    authClient.nonce = () => nonce;
+
+    nock(EXCHANGE_API_URL, { reqheaders: SignRequest(auth, payload) })
+      .post(request)
+      .times(1)
+      .reply(200, response);
+
+    authClient
+      .getNotionalVolume()
+      .then(data => {
+        assert.deepEqual(data, response);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
+
+  test('.getTradeVolume()', done => {
+    const response = [
+      [
+        {
+          account_id: 5365,
+          symbol: 'btcusd',
+          base_currency: 'BTC',
+          notional_currency: 'USD',
+          data_date: '2019-01-10',
+          total_volume_base: 8.06021756,
+          maker_buy_sell_ratio: 1,
+          buy_maker_base: 6.06021756,
+          buy_maker_notional: 23461.3515203844,
+          buy_maker_count: 34,
+          sell_maker_base: 0,
+          sell_maker_notional: 0,
+          sell_maker_count: 0,
+          buy_taker_base: 0,
+          buy_taker_notional: 0,
+          buy_taker_count: 0,
+          sell_taker_base: 2,
+          sell_taker_notional: 7935.66,
+          sell_taker_count: 2,
+        },
+        {
+          account_id: 5365,
+          symbol: 'ltcusd',
+          base_currency: 'LTC',
+          notional_currency: 'USD',
+          data_date: '2019-01-11',
+          total_volume_base: 3,
+          maker_buy_sell_ratio: 0,
+          buy_maker_base: 0,
+          buy_maker_notional: 0,
+          buy_maker_count: 0,
+          sell_maker_base: 0,
+          sell_maker_notional: 0,
+          sell_maker_count: 0,
+          buy_taker_base: 3,
+          buy_taker_notional: 98.22,
+          buy_taker_count: 3,
+          sell_taker_base: 0,
+          sell_taker_notional: 0,
+          sell_taker_count: 0,
+        },
+      ],
+    ];
+    const request = '/v1/tradevolume';
+    const nonce = 1;
+    const payload = { request, nonce };
+    authClient.nonce = () => nonce;
+
+    nock(EXCHANGE_API_URL, { reqheaders: SignRequest(auth, payload) })
+      .post(request)
+      .times(1)
+      .reply(200, response);
+
+    authClient
+      .getTradeVolume()
+      .then(data => {
+        assert.deepEqual(data, response);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
 });


### PR DESCRIPTION
## AuthenticatedClient
 - https://github.com/vansergen/gemini-node-api/commit/5e66f72b84e57a5e51b871bf29704c37b9985abe Add `getNotionalVolume` method
- https://github.com/vansergen/gemini-node-api/commit/96cfb5898eda55ee590d0c906fb8585d690963e9 Add `getTradeVolume` method

#### Other changes
- https://github.com/vansergen/gemini-node-api/commit/47deb236932393c2e4f5b789b7976c7bcd28ccfc Update tests
- https://github.com/vansergen/gemini-node-api/commit/fa1c11237b474b85a300e6cfe06fd9c16f30593a Update `README`
- https://github.com/vansergen/gemini-node-api/commit/eee1bcfb95b24bae1733a3d63abab435c58ba62d Update `Typescript` definitions