### PR TITLE
Add callback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,19 @@ publicClient
   });
 ```
 
+- `cb`
+
+```javascript
+const callback = (error, data) => {
+  if (error) {
+    console.error(error);
+  } else {
+    console.info(data);
+  }
+};
+publicClient.cb('getTicker', callback, { symbol: 'bchusd' });
+```
+
 ### AuthenticatedClient
 
 ```javascript
@@ -132,7 +145,20 @@ const volume = await authClient.getTradeVolume();
 - `post`
 
 ```javascript
-await authClient.post({ request: '/v1/tradevolume' });
+const volume = await authClient.post({ request: '/v1/tradevolume' });
+```
+
+- `cb`
+
+```javascript
+const callback = (error, data) => {
+  if (error) {
+    console.error(error);
+  } else {
+    console.info(data);
+  }
+};
+authClient.cb('getNotionalVolume', callback);
 ```
 
 ### SignRequest

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,8 @@
 import * as Promise from 'bluebird';
 
 declare module 'gemini-node-api' {
+  export type callback<T> = (error: any, data: T) => void;
+
   export type JSONObject = {
     [key: string]: any;
   };
@@ -179,6 +181,8 @@ declare module 'gemini-node-api' {
     get(options: GetOptions): Promise<RequestResponse>;
 
     request(options: RequestOptions): Promise<RequestResponse>;
+
+    cb(method: string, callback: callback<any>, options?: JSONObject);
 
     getSymbols(): Promise<string[]>;
 

--- a/lib/public.js
+++ b/lib/public.js
@@ -7,7 +7,13 @@ const {
   EXCHANGE_API_URL,
   SANDBOX_API_URL,
   HEADERS,
-} = require('./utilities');
+} = require('./utilities.js');
+
+/**
+ * @callback Callback
+ * @param error
+ * @param data
+ */
 
 class PublicClient {
   /**
@@ -87,6 +93,31 @@ class PublicClient {
         })
         .catch(error => reject(error));
     });
+  }
+
+  /**
+   * @param {string} method - Class method to call.
+   * @param {Callback} callback
+   * @param {Object} [options] - Optional parameters.
+   * @example
+   * const callback = (error, data) => {
+   *   if (error) {
+   *     console.error(error);
+   *   } else {
+   *     console.info(data);
+   *   }
+   * };
+   * publicClient.cb('getSymbols', callback);
+   * @description Make a callback-style request.
+   */
+  cb(method, callback, options) {
+    try {
+      this[method].call(this, options).then(data => {
+        callback(null, data);
+      });
+    } catch (error) {
+      callback(error);
+    }
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-node-api",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,9 +14,9 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
@@ -25,9 +25,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-      "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.0.tgz",
+      "integrity": "sha512-I5nW8AhGpOXGCCNYGc+p7ExQIBxRFnS2fd/d862bNOKvmoEPjYPcfIjsfdy0ujagYOIYPczKgD9l3FsgTkAzKA==",
       "dev": true
     },
     "@types/bluebird": {
@@ -36,9 +36,9 @@
       "integrity": "sha512-6BmYWSBea18+tSjjSC3QIyV93ZKAeNWGM7R6aYt1ryTZXrlHF+QLV0G2yV0viEGVyRkyQsWfMoJ0k/YghBX5sQ=="
     },
     "acorn": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
+      "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
       "dev": true
     },
     "acorn-jsx": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-node-api",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Gemini Node.js API",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## PublicClient
 - https://github.com/vansergen/gemini-node-api/commit/bf22290cdc94d08e8bc6e394881a63bb260f5f2e Add `cb` method

#### Other changes
- https://github.com/vansergen/gemini-node-api/commit/08cfe6a8ef6204619a140208eebf4270655c1c4f Update tests
- https://github.com/vansergen/gemini-node-api/commit/34198855cf0e00c4af08195cee420751faa12ce7 Update `README`
- https://github.com/vansergen/gemini-node-api/commit/f3b8b056a4dc7173786740147255544ef54da7d0 Update `Typescript` definitions
- https://github.com/vansergen/gemini-node-api/commit/b5aa28f2b78cce8b911885ee5afdd44b245f2502 Update `npm` version