### PR TITLE
Add cancelOrder method

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ const order = await authClient.newOrder({
 });
 ```
 
+- [`cancelOrder`](https://docs.gemini.com/rest-api/#cancel-order)
+
+```javascript
+const order_id = 106817811;
+const order = await authClient.cancelOrder({ order_id });
+```
+
 - [`getNotionalVolume`](https://docs.gemini.com/rest-api/#get-notional-volume)
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -56,6 +56,10 @@ declare module 'gemini-node-api' {
     ioi?: boolean;
   };
 
+  export type OrderID = {
+    order_id: number;
+  };
+
   export type TransferFilter = {
     timestamp?: number;
     limit_transfers?: number;
@@ -312,6 +316,8 @@ declare module 'gemini-node-api' {
     post(options: PostOptions): Promise<RequestResponse>;
 
     newOrder(options: OrderOptions): Promise<OrderStatus>;
+
+    cancelOrder(options: OrderID): Promise<OrderStatus>;
 
     getNotionalVolume(): Promise<NotionalVolume>;
 

--- a/lib/authenticated.js
+++ b/lib/authenticated.js
@@ -127,6 +127,22 @@ class AuthenticatedClient extends PublicClient {
   }
 
   /**
+   * @param {Object} options={}
+   * @param {number} options.order_id - The order ID.
+   * @example
+   * const order_id = 106817811;
+   * const order = await authClient.cancelOrder({ order_id });
+   * @throws Will throw an error if `options.order_id` is undefined.
+   * @description Cancel order by `order_id`.
+   * @see {@link https://docs.gemini.com/rest-api/#cancel-order|cancel-order}
+   */
+  cancelOrder({ order_id } = {}) {
+    this._requireProperties(order_id);
+
+    return this.post({ request: '/v1/order/cancel', order_id });
+  }
+
+  /**
    * @example
    * const volume = await authClient.getNotionalVolume();
    * @description Get the volume in price currency that has been traded across all pairs over a period of 30 days.

--- a/tests/authenticated.spec.js
+++ b/tests/authenticated.spec.js
@@ -241,6 +241,49 @@ suite('AuthenticatedClient', () => {
       .catch(error => assert.fail(error));
   });
 
+  test('.cancelOrder()', done => {
+    const order_id = 106817811;
+
+    const request = '/v1/order/cancel';
+    const nonce = 1;
+    authClient.nonce = () => nonce;
+
+    const payload = { request, order_id, nonce };
+    const response = {
+      order_id: '106817811',
+      id: '106817811',
+      symbol: 'btcusd',
+      exchange: 'gemini',
+      avg_execution_price: '3632.85101103',
+      side: 'buy',
+      type: 'exchange limit',
+      timestamp: '1547220404',
+      timestampms: 1547220404836,
+      is_live: false,
+      is_cancelled: true,
+      is_hidden: false,
+      was_forced: false,
+      executed_amount: '3.7610296649',
+      remaining_amount: '1.2389703351',
+      reason: 'Requested',
+      options: [],
+      price: '3633.00',
+      original_amount: '5',
+    };
+    nock(EXCHANGE_API_URL, { reqheaders: SignRequest(auth, payload) })
+      .post(request)
+      .times(1)
+      .reply(200, response);
+
+    authClient
+      .cancelOrder({ order_id })
+      .then(data => {
+        assert.deepStrictEqual(data, response);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
+
   test('.getNotionalVolume()', done => {
     const response = {
       web_maker_fee_bps: 100,


### PR DESCRIPTION
## AuthenticatedClient
 - https://github.com/vansergen/gemini-node-api/commit/9babc0a65eae766b6b6c9a74fb786b1ee9cf8969 Add `cancelOrder` method

#### Other changes
- https://github.com/vansergen/gemini-node-api/commit/b3f9902043cda500210f8b2e71c526573b72e865 Update tests
- https://github.com/vansergen/gemini-node-api/commit/0259903974fa197cf6cd02ccf75d116fcf8030d1 Update `README`
- https://github.com/vansergen/gemini-node-api/commit/4629292d71792f03b5a40bbac6a547122cd58412 Update `Typescript` definitions