### PR TITLE
Add getPastTrades method

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,19 @@ const order = await authClient.getOrderStatus({ order_id });
 const orders = await authClient.getActiveOrders();
 ```
 
+- [`getPastTrades`](https://docs.gemini.com/rest-api/#get-past-trades)
+
+```javascript
+const symbol = 'bcheth';
+const limit_trades = 10;
+const timestamp = 1547232911;
+const trades = await authClient.getPastTrades({
+  symbol,
+  limit_trades,
+  timestamp,
+});
+```
+
 - [`getNotionalVolume`](https://docs.gemini.com/rest-api/#get-notional-volume)
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,11 @@ declare module 'gemini-node-api' {
     order_id: number;
   };
 
+  export type PastTradesFilter = {
+    limit_trades?: number;
+    timestamp?: number;
+  } & SymbolFilter;
+
   export type TransferFilter = {
     timestamp?: number;
     limit_transfers?: number;
@@ -192,6 +197,23 @@ declare module 'gemini-node-api' {
       cancelledOrders: number[];
       cancelRejects: number[];
     };
+  };
+
+  export type PastTrade = {
+    price: string;
+    amount: string;
+    timestamp: number;
+    timestampms: number;
+    type: 'Buy' | 'Sell';
+    aggressor: boolean;
+    fee_currency: string;
+    fee_amount: string;
+    tid: number;
+    order_id: string;
+    client_order_id?: string;
+    exchange?: 'gemini';
+    is_auction_fill: boolean;
+    break?: string;
   };
 
   export type NotionalVolume = {
@@ -334,6 +356,8 @@ declare module 'gemini-node-api' {
     getOrderStatus(options: OrderID): Promise<OrderStatus>;
 
     getActiveOrders(): Promise<OrderStatus[]>;
+
+    getPastTrades(options?: PastTradesFilter): Promise<PastTrade[]>;
 
     getNotionalVolume(): Promise<NotionalVolume>;
 

--- a/lib/authenticated.js
+++ b/lib/authenticated.js
@@ -1,5 +1,6 @@
 const PublicClient = require('./public.js');
 const SignRequest = require('./signer.js');
+const { API_LIMIT } = require('./utilities.js');
 
 class AuthenticatedClient extends PublicClient {
   /**
@@ -186,6 +187,29 @@ class AuthenticatedClient extends PublicClient {
    */
   getActiveOrders() {
     return this.post({ request: '/v1/orders' });
+  }
+
+  /**
+   * @param {Object} [options={}]
+   * @param {string} [options.symbol] - The symbol to retrieve trades for.
+   * @param {number} [options.limit_trades] - The maximum number of trades to return.
+   * @param {number} [options.timestamp] - Only return trades on or after this timestamp.
+   * @example
+   * const trades = await authClient.getPastTrades();
+   * @description Get your past trades.
+   * @see {@link https://docs.gemini.com/rest-api/#get-past-trades|get-past-trades}
+   */
+  getPastTrades({
+    symbol = this.symbol,
+    limit_trades = API_LIMIT,
+    timestamp,
+  } = {}) {
+    return this.post({
+      request: '/v1/mytrades',
+      symbol,
+      limit_trades,
+      timestamp,
+    });
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-node-api",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-node-api",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Gemini Node.js API",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## AuthenticatedClient
 - https://github.com/vansergen/gemini-node-api/commit/08032120507bf3b5411a80236eb980098c447c9e Add `getPastTrades` method

#### Other changes
- https://github.com/vansergen/gemini-node-api/commit/caf4eca2754e6933fc68c3f97f4815fefca454e5 Update tests
- https://github.com/vansergen/gemini-node-api/commit/6116bfef72b8debf134dbb35280c0513d802f0d8 Update `README`
- https://github.com/vansergen/gemini-node-api/commit/482dc21975d175d9aa0f097cc0fa2f6c5129bcd4 Update `Typescript` definitions
- https://github.com/vansergen/gemini-node-api/commit/3d02e78db7dc4c509e271e67e6dcc0ebd5997923 Update `npm` version to `0.2.3`