### PR TITLE
Add buy and sell methods

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,13 +6,14 @@
   },
   "parserOptions": {
     "sourceType": "module",
-    "ecmaVersion": 9
+    "ecmaVersion": 2019
   },
   "rules": {
     "curly": "error",
     "eqeqeq": "error",
     "func-names": "error",
     "linebreak-style": "error",
+    "no-console": "error",
     "quotes": ["error", "single"],
     "prefer-destructuring": "error",
     "semi": "error"

--- a/README.md
+++ b/README.md
@@ -147,6 +147,24 @@ const order = await authClient.newOrder({
 });
 ```
 
+- [`buy`](https://docs.gemini.com/rest-api/#new-order)
+
+```javascript
+const symbol = 'zecltc';
+const amount = 1;
+const price = 0.9;
+const order = await authClient.buy({ symbol, amount, price });
+```
+
+- [`sell`](https://docs.gemini.com/rest-api/#new-order)
+
+```javascript
+const symbol = 'zecltc';
+const amount = 0.99;
+const price = 0.99;
+const order = await authClient.sell({ symbol, amount, price });
+```
+
 - [`cancelOrder`](https://docs.gemini.com/rest-api/#cancel-order)
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,19 +42,22 @@ declare module 'gemini-node-api' {
     include_indicative?: boolean;
   } & SymbolFilter;
 
-  export type OrderOptions = {
+  export type BasicOrderOptions = {
     client_order_id?: string;
     symbol?: string;
     amount: number;
     min_amount?: number;
     price: number;
-    side: 'buy' | 'sell';
     moc?: boolean;
     ioc?: boolean;
     fok?: boolean;
     ao?: boolean;
     ioi?: boolean;
   };
+
+  export type OrderOptions = {
+    side: 'buy' | 'sell';
+  } & BasicOrderOptions;
 
   export type OrderID = {
     order_id: number;
@@ -346,6 +349,10 @@ declare module 'gemini-node-api' {
     post(options: PostOptions): Promise<RequestResponse>;
 
     newOrder(options: OrderOptions): Promise<OrderStatus>;
+
+    buy(options: BasicOrderOptions): Promise<OrderStatus>;
+
+    sell(options: BasicOrderOptions): Promise<OrderStatus>;
 
     cancelOrder(options: OrderID): Promise<OrderStatus>;
 

--- a/lib/authenticated.js
+++ b/lib/authenticated.js
@@ -101,17 +101,13 @@ class AuthenticatedClient extends PublicClient {
     const options = [];
     if (moc) {
       options.push('maker-or-cancel');
-    }
-    if (ioc) {
+    } else if (ioc) {
       options.push('immediate-or-cancel');
-    }
-    if (fok) {
+    } else if (fok) {
       options.push('fill-or-kill');
-    }
-    if (ao) {
+    } else if (ao) {
       options.push('auction-only');
-    }
-    if (ioi) {
+    } else if (ioi) {
       options.push('indication-of-interest');
     }
     return this.post({

--- a/lib/authenticated.js
+++ b/lib/authenticated.js
@@ -124,6 +124,22 @@ class AuthenticatedClient extends PublicClient {
   }
 
   /**
+   * @description Submit buy order.
+   * @param {{...*}} [options] - The same parameters as in `newOrder`.
+   */
+  buy({ ...options } = {}) {
+    return this.newOrder({ ...options, side: 'buy' });
+  }
+
+  /**
+   * @description Submit sell order.
+   * @param {{...*}} [options] - The same parameters as in `newOrder`.
+   */
+  sell({ ...options } = {}) {
+    return this.newOrder({ ...options, side: 'sell' });
+  }
+
+  /**
    * @param {Object} options={}
    * @param {number} options.order_id - The order ID.
    * @example

--- a/tests/authenticated.spec.js
+++ b/tests/authenticated.spec.js
@@ -241,6 +241,160 @@ suite('AuthenticatedClient', () => {
       .catch(error => assert.fail(error));
   });
 
+  test('.buy() (ignores `side`)', done => {
+    const symbol = 'btcusd';
+    const client_order_id = '20190110-4738721';
+    const amount = 5;
+    const min_amount = 1;
+    const price = 3633.0;
+    const side = 'buy';
+    const moc = true;
+    const ioc = false;
+    const fok = false;
+    const ao = false;
+    const ioi = false;
+    const type = 'exchange limit';
+
+    const request = '/v1/order/new';
+    const nonce = 1;
+    authClient.nonce = () => nonce;
+
+    const payload = {
+      request,
+      client_order_id,
+      symbol,
+      amount,
+      min_amount,
+      price,
+      side,
+      type,
+      options: ['maker-or-cancel'],
+      nonce,
+    };
+    const response = {
+      order_id: '106817811',
+      id: '106817811',
+      symbol: 'btcusd',
+      exchange: 'gemini',
+      avg_execution_price: '3632.8508430064554',
+      side: 'buy',
+      type: 'exchange limit',
+      timestamp: '1547220404',
+      timestampms: 1547220404836,
+      is_live: true,
+      is_cancelled: false,
+      is_hidden: false,
+      was_forced: false,
+      executed_amount: '3.7567928949',
+      remaining_amount: '1.2432071051',
+      client_order_id: '20190110-4738721',
+      options: [],
+      price: '3633.00',
+      original_amount: '5',
+    };
+    nock(EXCHANGE_API_URL, { reqheaders: SignRequest(auth, payload) })
+      .post(request)
+      .times(1)
+      .reply(200, response);
+
+    authClient
+      .buy({
+        symbol,
+        client_order_id,
+        amount,
+        min_amount,
+        price,
+        side: 'sell',
+        moc,
+        ioc,
+        fok,
+        ao,
+        ioi,
+      })
+      .then(data => {
+        assert.deepStrictEqual(data, response);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
+
+  test('.sell() (ignores `side`)', done => {
+    const symbol = 'btcusd';
+    const client_order_id = '20190110-4738721';
+    const amount = 5;
+    const min_amount = 1;
+    const price = 3633.0;
+    const side = 'sell';
+    const moc = true;
+    const ioc = false;
+    const fok = false;
+    const ao = false;
+    const ioi = false;
+    const type = 'exchange limit';
+
+    const request = '/v1/order/new';
+    const nonce = 1;
+    authClient.nonce = () => nonce;
+
+    const payload = {
+      request,
+      client_order_id,
+      symbol,
+      amount,
+      min_amount,
+      price,
+      side,
+      type,
+      options: ['maker-or-cancel'],
+      nonce,
+    };
+    const response = {
+      order_id: '106817811',
+      id: '106817811',
+      symbol: 'btcusd',
+      exchange: 'gemini',
+      avg_execution_price: '3632.8508430064554',
+      side: 'buy',
+      type: 'exchange limit',
+      timestamp: '1547220404',
+      timestampms: 1547220404836,
+      is_live: true,
+      is_cancelled: false,
+      is_hidden: false,
+      was_forced: false,
+      executed_amount: '3.7567928949',
+      remaining_amount: '1.2432071051',
+      client_order_id: '20190110-4738721',
+      options: [],
+      price: '3633.00',
+      original_amount: '5',
+    };
+    nock(EXCHANGE_API_URL, { reqheaders: SignRequest(auth, payload) })
+      .post(request)
+      .times(1)
+      .reply(200, response);
+
+    authClient
+      .sell({
+        symbol,
+        client_order_id,
+        amount,
+        min_amount,
+        price,
+        side: 'buy',
+        moc,
+        ioc,
+        fok,
+        ao,
+        ioi,
+      })
+      .then(data => {
+        assert.deepStrictEqual(data, response);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
+
   test('.cancelOrder()', done => {
     const order_id = 106817811;
 

--- a/tests/authenticated.spec.js
+++ b/tests/authenticated.spec.js
@@ -115,7 +115,7 @@ suite('AuthenticatedClient', () => {
     const side = 'buy';
     const moc = true;
     const ioc = false;
-    const fok = true;
+    const fok = false;
     const ao = false;
     const ioi = false;
     const type = 'exchange limit';
@@ -133,7 +133,7 @@ suite('AuthenticatedClient', () => {
       price,
       side,
       type,
-      options: ['maker-or-cancel', 'fill-or-kill'],
+      options: ['maker-or-cancel'],
       nonce,
     };
     const response = {


### PR DESCRIPTION
## AuthenticatedClient
 - https://github.com/vansergen/gemini-node-api/commit/1a8ff5f59003cb419edc676187631e48dd08a750 Add `buy` and `sell` methods
- https://github.com/vansergen/gemini-node-api/commit/bd141ec0935187020a0370ec2f1b14a0a1f1d40c - Allow only one flag in `newOrder` method

#### Other changes
- https://github.com/vansergen/gemini-node-api/commit/06696eac27cbd7cde231a3efea4ad65038b51645 Update tests
- https://github.com/vansergen/gemini-node-api/commit/4c26610a43858137361adee3c0219311f173497b Update `README`
- https://github.com/vansergen/gemini-node-api/commit/774bbd81a161b27a286d94dea8096849981d71a4 Update `Typescript` definitions
- https://github.com/vansergen/gemini-node-api/commit/374c3accf88ad68aa7b3d419cabf4c41ee604fc2 Change `ecmaVersion` version to `2019` and add `no-console` rule to `.eslintrc.json`