### PR TITLE
Add connectOrders method

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,20 @@ websocket.once('close', market => console.log('Closed:', market));
 websocket.disconnectMarket({ symbol });
 ```
 
+- [`connectOrders`](https://docs.gemini.com/websocket-api/#order-events)
+
+```javascript
+const symbolFilter = 'zecltc';
+const apiSessionFilter = 'UI';
+const eventTypeFilter = ['accepted', 'rejected'];
+websocket.on('message', (message, market) => {
+  if (market === 'orders') {
+    console.log('New message:', message);
+  }
+});
+websocket.connectOrders({ symbolFilter, apiSessionFilter, eventTypeFilter });
+```
+
 ### SignRequest
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -104,6 +104,12 @@ declare module 'gemini-node-api' {
     auctions?: boolean;
   };
 
+  export type WSOrderOptions = {
+    symbolFilter?: string | string[];
+    apiSessionFilter?: string | string[];
+    eventTypeFilter?: string | string[];
+  };
+
   export type Auth = {
     key: string;
     secret: string;
@@ -409,6 +415,8 @@ declare module 'gemini-node-api' {
     constructor(options?: WebsocketClientOptions);
 
     connectMarket(options?: WSMarketOptions): void;
+
+    connectOrders(options?: WSOrderOptions): void;
 
     disconnectMarket(options?: SymbolFilter): void;
 

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -1,3 +1,4 @@
+const SignRequest = require('./signer.js');
 const Websocket = require('ws');
 const EventEmitter = require('events');
 const querystring = require('querystring');
@@ -70,6 +71,37 @@ class WebsocketClient extends EventEmitter {
     const uri = this.api_uri + '/v1/marketdata/' + symbol + qs;
     this.sockets[symbol] = new Websocket(uri);
     this._addListeners(this.sockets[symbol], symbol);
+  }
+
+  /**
+   * @param {Object} [options]
+   * @param {string|string[]} [options.symbolFilter] - Optional symbol filter for order event subscription.
+   * @param {string|string[]} [options.apiSessionFilter] - Optional API session key filter for order event subscription.
+   * @param {string|string[]} [options.eventTypeFilter] - Optional order event type filter for order event subscription.
+   * @example
+   * websocket.connectOrders();
+   * @description Connect to the private API that gives you information about your orders in real time.
+   * @see {@link https://docs.gemini.com/websocket-api/#order-events|order-events}
+   */
+  connectOrders({ symbolFilter, apiSessionFilter, eventTypeFilter } = {}) {
+    if (!this.key || !this.secret) {
+      throw new Error('`connectOrders` requires both `key` and `secret`');
+    }
+
+    const options = { symbolFilter, apiSessionFilter, eventTypeFilter };
+    _checkUndefined(options, true);
+    let qs = querystring.stringify(options);
+    if (qs) {
+      qs = '?' + qs;
+    }
+    const auth = { key: this.key, secret: this.secret };
+    const request = '/v1/order/events';
+    const nonce = this._nonce();
+    const headers = SignRequest(auth, { request, nonce });
+    const uri = this.api_uri + request + qs;
+
+    this.sockets.orders = new Websocket(uri, { headers });
+    this._addListeners(this.sockets.orders, 'orders');
   }
 
   /**

--- a/tests/websocket.spec.js
+++ b/tests/websocket.spec.js
@@ -143,4 +143,34 @@ suite('WebsocketClient', () => {
     });
     client.connectMarket();
   });
+
+  test('connectOrders()', done => {
+    const server = wss({ port, key, secret });
+    const client = new WebsocketClient({ api_uri, key, secret });
+    client.once('message', (message, type) => {
+      assert.deepStrictEqual(message.socket_sequence, 0);
+      assert.deepStrictEqual(type, 'orders');
+      server.close();
+      done();
+    });
+    client.connectOrders();
+  });
+
+  test('connectOrders() (with extra parameters)', done => {
+    const symbolFilter = ['btcusd', 'ethbtc'];
+    const eventTypeFilter = ['initial', 'fill', 'closed'];
+    const apiSessionFilter = ['UI', key];
+    const server = wss({ port, key, secret });
+    const client = new WebsocketClient({ api_uri, key, secret });
+    client.once('message', (message, type) => {
+      assert.deepStrictEqual(message.socket_sequence, 0);
+      assert.deepStrictEqual(type, 'orders');
+      assert.deepStrictEqual(message.symbolFilter, symbolFilter);
+      assert.deepStrictEqual(message.eventTypeFilter, eventTypeFilter);
+      assert.deepStrictEqual(message.apiSessionFilter, apiSessionFilter);
+      server.close();
+      done();
+    });
+    client.connectOrders({ symbolFilter, eventTypeFilter, apiSessionFilter });
+  });
 });


### PR DESCRIPTION
## WebsocketClient
 - https://github.com/vansergen/gemini-node-api/commit/9b9a710caf9e4782280fa6b0cd72957e13695d62 Add `connectOrders` method

#### Other changes
- https://github.com/vansergen/gemini-node-api/commit/b99c457bda54b5b6144f75453bf9295b5b4c86df Update tests
- https://github.com/vansergen/gemini-node-api/commit/fe6e3ad2c367d91c54ef8e054dd5cee9c7738a85 Update `README`
- https://github.com/vansergen/gemini-node-api/commit/eb750a637169cc95bf5243b3f6ee1695f4900c99 Update `Typescript` definitions