### PR TITLE
Add V2 support to the getTicker method 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ const symbols = await publicClient.getSymbols();
 ```javascript
 const symbol = 'zecltc';
 const ticker = await publicClient.getTicker({ symbol });
+/**
+ * for V2
+ * @see https://docs.gemini.com/rest-api/#ticker-v2
+ */
+const v = 'v2';
+const tickerV2 = await publicClient.getTicker({ symbol, v });
 ```
 
 - [`getOrderBook`](https://docs.gemini.com/rest-api/#current-order-book)

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,10 @@ declare module 'gemini-node-api' {
     symbol?: string;
   };
 
+  export type TickerFilter = SymbolFilter & {
+    v?: 'v1' | 'v2';
+  };
+
   export type BookFilter = {
     limit_bids?: number;
     limit_asks?: number;
@@ -121,13 +125,25 @@ declare module 'gemini-node-api' {
     | JSONObject[][]
     | string[];
 
-  export type Ticker = {
+  export type TickerV1 = {
     bid: string;
     ask: string;
     last: string;
     volume: JSONObject;
   };
 
+  export type TickerV2 = {
+    symbol: string;
+    open: string;
+    high: string;
+    low: string;
+    close: string;
+    changes: string[];
+    bid: string;
+    ask: string;
+  };
+
+  export type Ticker = TickerV1 | TickerV2;
   export type BookEntry = {
     price: string;
     amount: string;
@@ -358,7 +374,7 @@ declare module 'gemini-node-api' {
 
     getSymbols(): Promise<string[]>;
 
-    getTicker(options?: SymbolFilter): Promise<Ticker>;
+    getTicker(options?: TickerFilter): Promise<Ticker>;
 
     getOrderBook(options?: BookFilter): Promise<OrderBook>;
 

--- a/lib/public.js
+++ b/lib/public.js
@@ -130,19 +130,22 @@ class PublicClient {
   }
 
   /**
-   * @param {Object} [options]
+   * @param {Object} [options={}]
    * @param {string} [options.symbol] - Trading symbol.
+   * @param {string} [options.v='v1'] - `v1` or `v2`.
    * @example
    * const ticker = await publicClient.getTicker();
    * @description Get information about recent trading activity for the symbol.
    * @see {@link https://docs.gemini.com/rest-api/#ticker|ticker}
+   * @see {@link https://docs.gemini.com/rest-api/#ticker-v2|ticker-v2}
    */
-  getTicker({ symbol = this.symbol } = {}) {
-    return this.get({ uri: 'v1/pubticker/' + symbol });
+  getTicker({ symbol = this.symbol, v = 'v1' } = {}) {
+    v += v === 'v1' ? '/pubticker/' + symbol : '/ticker/' + symbol;
+    return this.get({ uri: v });
   }
 
   /**
-   * @param {Object} [options]
+   * @param {Object} [options={}]
    * @param {string} [options.symbol] - Trading symbol.
    * @param {number} [options.limit_bids=0] - Limit the number of bids (offers to buy) returned.
    * @param {number} [options.limit_asks=0] - Limit the number of asks (offers to sell) returned.
@@ -156,7 +159,7 @@ class PublicClient {
   }
 
   /**
-   * @param {Object} [options]
+   * @param {Object} [options={}]
    * @param {string} [options.symbol] - Trading symbol.
    * @param {number} [options.since] - Only return trades after this timestamp.
    * @param {number} [options.limit_trades] - The maximum number of trades to return.
@@ -181,7 +184,7 @@ class PublicClient {
   }
 
   /**
-   * @param {Object} [options]
+   * @param {Object} [options={}]
    * @param {string} [options.symbol] - Trading symbol.
    * @example
    * const auction = await publicClient.getCurrentAuction();
@@ -193,7 +196,7 @@ class PublicClient {
   }
 
   /**
-   * @param {Object} [options]
+   * @param {Object} [options={}]
    * @param {string} [options.symbol] - Trading symbol.
    * @param {number} [options.since] - Only return trades after this timestamp.
    * @param {number} [options.limit_auction_results] - The maximum number of auction events to return.

--- a/tests/public.spec.js
+++ b/tests/public.spec.js
@@ -124,9 +124,7 @@ suite('PublicClient', () => {
         .request({ uri })
         .then(() => assert.fail('Should have thrown an error'))
         .catch(error => {
-          assert.deepStrictEqual(error.message, response.message);
-          assert.deepStrictEqual(error.reason, response.reason);
-          assert.deepStrictEqual(error.result, response.result);
+          assert.deepStrictEqual(error, response);
           done();
         });
     });
@@ -148,9 +146,7 @@ suite('PublicClient', () => {
         .request({ uri })
         .then(() => assert.fail('Should have thrown an error'))
         .catch(error => {
-          assert.deepStrictEqual(error.message, response.message);
-          assert.deepStrictEqual(error.reason, response.reason);
-          assert.deepStrictEqual(error.result, response.result);
+          assert.deepStrictEqual(error, response);
           done();
         });
     });
@@ -171,9 +167,7 @@ suite('PublicClient', () => {
         .request({ uri })
         .then(() => assert.fail('Should have thrown an error'))
         .catch(error => {
-          assert.deepStrictEqual(error.message, response.message);
-          assert.deepStrictEqual(error.reason, response.reason);
-          assert.deepStrictEqual(error.result, response.result);
+          assert.deepStrictEqual(error, response);
           done();
         });
     });
@@ -181,7 +175,7 @@ suite('PublicClient', () => {
 
   test('.get()', done => {
     const symbol = 'btcusd';
-    const uri = 'v1/auction/' + symbol;
+    const uri = '/v1/auction/' + symbol;
     const response = {
       closed_until_ms: 1474567602895,
       last_auction_price: '629.92',
@@ -192,7 +186,7 @@ suite('PublicClient', () => {
       next_auction_ms: 1474567782895,
     };
     nock(EXCHANGE_API_URL)
-      .get('/' + uri)
+      .get(uri)
       .times(1)
       .reply(200, response);
 
@@ -265,6 +259,58 @@ suite('PublicClient', () => {
       .catch(error => assert.fail(error));
   });
 
+  test('.getTicker() (v2)', done => {
+    const symbol = 'btcusd';
+    const uri = '/v2/ticker/' + symbol;
+    const response = {
+      symbol: 'BTCUSD',
+      open: '9121.76',
+      high: '9440.66',
+      low: '9106.51',
+      close: '9347.66',
+      changes: [
+        '9365.1',
+        '9386.16',
+        '9373.41',
+        '9322.56',
+        '9268.89',
+        '9265.38',
+        '9245',
+        '9231.43',
+        '9235.88',
+        '9265.8',
+        '9295.18',
+        '9295.47',
+        '9310.82',
+        '9335.38',
+        '9344.03',
+        '9261.09',
+        '9265.18',
+        '9282.65',
+        '9260.01',
+        '9225',
+        '9159.5',
+        '9150.81',
+        '9118.6',
+        '9148.01',
+      ],
+      bid: '9345.70',
+      ask: '9347.67',
+    };
+    nock(EXCHANGE_API_URL)
+      .get(uri)
+      .times(1)
+      .reply(200, response);
+
+    publicClient
+      .getTicker({ symbol, v: 'v2' })
+      .then(data => {
+        assert.deepStrictEqual(data, response);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
+
   test('.getTicker() (with default symbol)', done => {
     const symbol = 'zecbtc';
     const uri = '/v1/pubticker/' + symbol;
@@ -294,6 +340,58 @@ suite('PublicClient', () => {
       .catch(error => assert.fail(error));
   });
 
+  test('.getTicker() (v2 with default symbol)', done => {
+    const symbol = 'zecbtc';
+    const uri = '/v2/ticker/' + symbol;
+    const response = {
+      symbol: 'zecbtc',
+      open: '9121.76',
+      high: '9440.66',
+      low: '9106.51',
+      close: '9347.66',
+      changes: [
+        '9365.1',
+        '9386.16',
+        '9373.41',
+        '9322.56',
+        '9268.89',
+        '9265.38',
+        '9245',
+        '9231.43',
+        '9235.88',
+        '9265.8',
+        '9295.18',
+        '9295.47',
+        '9310.82',
+        '9335.38',
+        '9344.03',
+        '9261.09',
+        '9265.18',
+        '9282.65',
+        '9260.01',
+        '9225',
+        '9159.5',
+        '9150.81',
+        '9118.6',
+        '9148.01',
+      ],
+      bid: '9345.70',
+      ask: '9347.67',
+    };
+    nock(EXCHANGE_API_URL)
+      .get(uri)
+      .times(1)
+      .reply(200, response);
+
+    const client = new PublicClient({ symbol });
+    client
+      .getTicker({ v: 'v2' })
+      .then(data => {
+        assert.deepStrictEqual(data, response);
+        done();
+      })
+      .catch(error => assert.fail(error));
+  });
   test('.getOrderBook()', done => {
     const symbol = 'btcusd';
     const uri = '/v1/book/' + symbol;


### PR DESCRIPTION
## PublicClient
 - https://github.com/vansergen/gemini-node-api/commit/5b3391883e450c37681694492bfca8d0cc51a5b6 Add V2 support to the `getTicker` method (see [here](https://docs.gemini.com/rest-api/#ticker-v2))

#### Other changes
- https://github.com/vansergen/gemini-node-api/commit/f18b46adb911318358146cc72b2838058ea838e5 Update tests
- https://github.com/vansergen/gemini-node-api/commit/50ee4bc7641f029a666ee05ae8b80beeacdb009d Update `README`
- https://github.com/vansergen/gemini-node-api/commit/5372c6d4dfa7bbfb9b26a513fc6d5b41bba60410 Update `Typescript` definitions