### PR TITLE
Fix time based nonce issue

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -404,7 +404,7 @@ export class AuthenticatedClient extends PublicClient {
     super(rest);
     this.#key = key;
     this.#secret = secret;
-    this.#nonce = (): number => Date.now();
+    this.#nonce = (): number => Math.floor(Date.now() / 1000);
   }
 
   public post<T = unknown>(

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -318,7 +318,7 @@ export class WebsocketClient extends EventEmitter {
       this.#key = key;
       this.#secret = secret;
     }
-    this.#nonce = (): number => Date.now();
+    this.#nonce = (): number => Math.floor(Date.now() / 1000);
   }
 
   /** Connect to the public API (V1) that streams all the market data on a given symbol. */


### PR DESCRIPTION
If user enable time based nonce, this lib will not work anymore 
Example error:
```
Nonce '1670305260021' is not within 30 seconds of server time '1670305261'
```
This attempts to change the nonce format to Gemini's server format